### PR TITLE
V0.5.4

### DIFF
--- a/packages/svogg-components/package.json
+++ b/packages/svogg-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svogg-components",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "A SvelteKit component library.",
 	"author": "MikaelJohnAndersson <mikael.andersson@moggstudio.se>",
 	"license": "MIT",

--- a/packages/svogg-components/src/lib/components/Switch/Switch.svelte
+++ b/packages/svogg-components/src/lib/components/Switch/Switch.svelte
@@ -1,0 +1,28 @@
+<script>
+	/**
+	 * Checked state
+	 * @type {boolean}
+	 */
+	export let checked = false;
+
+	function toggle() {
+		checked = !checked;
+	}
+
+	/** @param {KeyboardEvent} ev */
+	function handleKeyDown(ev) {
+		if (ev.code == 'Enter' || ev.code == 'Space') toggle();
+	}
+</script>
+
+<div
+	role="switch"
+	class="svogg-switch"
+	aria-checked={checked}
+	tabindex="0"
+	class:checked
+	on:click={toggle}
+	on:keydown={handleKeyDown}
+>
+	<span class="thumb" />
+</div>

--- a/packages/svogg-components/src/lib/components/Switch/Switch.svelte
+++ b/packages/svogg-components/src/lib/components/Switch/Switch.svelte
@@ -5,6 +5,12 @@
 	 */
 	export let checked = false;
 
+	/**
+	 * HTML `name` attribute
+	 * @type {string}
+	 */
+	export let name = undefined;
+
 	function toggle() {
 		checked = !checked;
 	}
@@ -25,4 +31,5 @@
 	on:keydown={handleKeyDown}
 >
 	<span class="thumb" />
+	<input style="display: none;" type="checkbox" bind:checked {name} />
 </div>

--- a/packages/svogg-components/src/lib/components/Switch/Switch.svelte
+++ b/packages/svogg-components/src/lib/components/Switch/Switch.svelte
@@ -6,13 +6,14 @@
 	export let checked = false;
 
 	/**
-	 * HTML `name` attribute
+	 * HTML `name` attribute for internal checkbox element
 	 * @type {string}
 	 */
 	export let name = undefined;
 
 	/**
-	 * HTML `aria-label` attribute for the switch element
+	 * 	HTML `aria-label` attribute for outer switch element
+	 *  @type {string}
 	 */
 	export let label = undefined;
 

--- a/packages/svogg-components/src/lib/components/Switch/Switch.svelte
+++ b/packages/svogg-components/src/lib/components/Switch/Switch.svelte
@@ -11,13 +11,18 @@
 	 */
 	export let name = undefined;
 
+	/**
+	 * HTML `aria-label` attribute for the switch element
+	 */
+	export let label = undefined;
+
 	function toggle() {
 		checked = !checked;
 	}
 
 	/** @param {KeyboardEvent} ev */
 	function handleKeyDown(ev) {
-		if (ev.code == 'Enter' || ev.code == 'Space') toggle();
+		if (['Enter', 'Space'].includes(ev.code)) toggle();
 	}
 </script>
 
@@ -25,6 +30,7 @@
 	role="switch"
 	class="svogg-switch"
 	aria-checked={checked}
+	aria-label={label}
 	tabindex="0"
 	class:checked
 	on:click={toggle}

--- a/packages/svogg-components/src/lib/components/Switch/Switch.test.ts
+++ b/packages/svogg-components/src/lib/components/Switch/Switch.test.ts
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom';
+import { render, type RenderResult } from '@testing-library/svelte';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+import Switch from './Switch.svelte';
+
+describe('Switch.svelte', () => {
+	let user: UserEvent;
+	let el: HTMLElement;
+	let Component: RenderResult<Switch>;
+
+	beforeEach(() => {
+		user = userEvent.setup();
+		Component = render(Switch);
+		el = Component.getByRole('switch');
+	});
+
+	it('toggles aria-checked on click', async () => {
+		expect(el).not.toHaveAttribute('aria-checked', 'true');
+		await user.click(el);
+		expect(el).toHaveAttribute('aria-checked', 'true');
+	});
+
+	it('adds class when checked', async () => {
+		expect(el).not.toHaveClass('checked');
+		await user.click(el);
+		expect(el).toHaveClass('checked');
+	});
+
+	it('toggles internal input state on click', async () => {
+		const { getByRole } = Component;
+		expect(getByRole('checkbox', { hidden: true })).not.toBeChecked();
+		await user.click(el);
+		expect(getByRole('checkbox', { hidden: true })).toBeChecked();
+	});
+
+	describe('toggles aria-checked on', () => {
+		it('enter', async () => {
+			el.focus();
+
+			expect(el).not.toHaveAttribute('aria-checked', 'true');
+			await user.keyboard('{Enter}');
+			expect(el).toHaveAttribute('aria-checked', 'true');
+		});
+
+		it('space', async () => {
+			el.focus();
+
+			expect(el).not.toHaveAttribute('aria-checked', 'true');
+			await user.keyboard('{ }');
+			expect(el).toHaveAttribute('aria-checked', 'true');
+		});
+	});
+});

--- a/packages/svogg-components/src/lib/components/Switch/index.js
+++ b/packages/svogg-components/src/lib/components/Switch/index.js
@@ -1,0 +1,2 @@
+import Switch from './Switch.svelte';
+export default Switch;

--- a/packages/svogg-components/src/lib/index.js
+++ b/packages/svogg-components/src/lib/index.js
@@ -1,5 +1,9 @@
+// Components
 export { default as ChipInput } from './components/ChipInput/index.js';
 export { default as Drawer } from './components/Drawer/index.js';
 export { TabList, Tab, TabPanel } from './components/Tabs/index.js';
+export { default as Switch } from './components/Switch/index.js';
+
+// Actions
 export { default as focusTrap } from './actions/focusTrap.js';
 export { default as clickOutside } from './actions/clickOutside.js';

--- a/packages/svogg-components/src/lib/styles/index.css
+++ b/packages/svogg-components/src/lib/styles/index.css
@@ -113,10 +113,15 @@ body {
 	border-radius: 9999px;
 	width: var(--width);
 	aspect-ratio: 2/1;
+	transition: all 0.2s;
 }
 
 .svogg-switch:hover {
 	cursor: pointer;
+}
+
+.svogg-switch.checked {
+	border-color: var(--svogg-primary);
 }
 
 .svogg-switch .thumb {
@@ -126,7 +131,7 @@ body {
 	border-radius: 9999px;
 	height: 100%;
 	aspect-ratio: 1/1;
-	background: var(--svogg-surface-300);
+	background: var(--svogg-surface-400);
 	transition: all 0.2s;
 	transform: scale(var(--thumb-scale));
 }

--- a/packages/svogg-components/src/lib/styles/index.css
+++ b/packages/svogg-components/src/lib/styles/index.css
@@ -30,6 +30,10 @@
 	--svogg-primary-saturation: 100%;
 	--svogg-primary-lightness: 20%;
 
+	--svogg-primary: hsl(
+		var(--svogg-primary-hue) var(--svogg-primary-saturation) var(--svogg-primary-lightness)
+	);
+
 	color: var(--svogg-text);
 }
 

--- a/packages/svogg-components/src/lib/styles/index.css
+++ b/packages/svogg-components/src/lib/styles/index.css
@@ -135,7 +135,10 @@ body {
 	border-radius: 9999px;
 	width: var(--width);
 	aspect-ratio: 2/1;
-	transition: all 0.2s;
+}
+
+.svogg-switch:focus-visible {
+	outline: solid 2px;
 }
 
 .svogg-switch:hover {
@@ -154,7 +157,7 @@ body {
 	height: 100%;
 	aspect-ratio: 1/1;
 	background-color: var(--svogg-surface-400);
-	transition: all 0.2s;
+	transition: transform 0.2s;
 	transform: scale(var(--thumb-scale));
 }
 

--- a/packages/svogg-components/src/lib/styles/index.css
+++ b/packages/svogg-components/src/lib/styles/index.css
@@ -25,6 +25,28 @@
 	}
 }
 
+/* Repeated properties, 'data-theme' overrides system settings */
+
+[data-theme='light'] {
+	--svogg-surface-100: hsl(var(--svogg-primary-hue) 20% 98%);
+	--svogg-surface-200: hsl(var(--svogg-primary-hue) 20% 95%);
+	--svogg-surface-300: hsl(var(--svogg-primary-hue) 20% 90%);
+	--svogg-surface-400: hsl(var(--svogg-primary-hue) 20% 80%);
+
+	--svogg-text: hsl(var(--svogg-primary-hue) var(--svogg-primary-saturation) 3%);
+	--svogg-text-light: hsl(var(--svogg-primary-hue) 30% 30%);
+}
+
+[data-theme='dark'] {
+	--svogg-surface-100: hsl(var(--svogg-primary-hue) 10% 10%);
+	--svogg-surface-200: hsl(var(--svogg-primary-hue) 10% 15%);
+	--svogg-surface-300: hsl(var(--svogg-primary-hue) 5% 20%);
+	--svogg-surface-400: hsl(var(--svogg-primary-hue) 5% 25%);
+
+	--svogg-text: hsl(var(--svogg-primary-hue) 15% 85%);
+	--svogg-text-light: hsl(var(--svogg-primary-hue) 5% 65%);
+}
+
 :root {
 	--svogg-primary-hue: 200;
 	--svogg-primary-saturation: 100%;

--- a/packages/svogg-components/src/lib/styles/index.css
+++ b/packages/svogg-components/src/lib/styles/index.css
@@ -50,7 +50,7 @@
 :root {
 	--svogg-primary-hue: 200;
 	--svogg-primary-saturation: 100%;
-	--svogg-primary-lightness: 20%;
+	--svogg-primary-lightness: 40%;
 
 	--svogg-primary: hsl(
 		var(--svogg-primary-hue) var(--svogg-primary-saturation) var(--svogg-primary-lightness)

--- a/packages/svogg-components/src/lib/styles/index.css
+++ b/packages/svogg-components/src/lib/styles/index.css
@@ -98,6 +98,42 @@ body {
 	border-color: var(--svogg-surface-400);
 }
 
+.svogg-switch {
+	--width: 48px;
+	--border: 2px;
+	--thumb-scale: 0.8;
+
+	position: relative;
+	display: flex;
+	border: var(--border) solid var(--svogg-surface-300);
+	border-radius: 9999px;
+	width: var(--width);
+	aspect-ratio: 2/1;
+}
+
+.svogg-switch:hover {
+	cursor: pointer;
+}
+
+.svogg-switch .thumb {
+	position: absolute;
+	left: 0;
+	top: 0;
+	border-radius: 9999px;
+	height: 100%;
+	aspect-ratio: 1/1;
+	background: var(--svogg-surface-300);
+	transition: all 0.2s;
+	transform: scale(var(--thumb-scale));
+}
+
+.svogg-switch.checked .thumb {
+	background: var(--svogg-primary);
+	border-color: var(--svogg-primary);
+	transform: scale(var(--thumb-scale)) translateX(calc(var(--width) - var(--border)))
+		translateX(calc(-100% * var(--thumb-scale)));
+}
+
 /* Extra classes */
 
 .svogg-input {

--- a/packages/svogg-components/src/lib/styles/index.css
+++ b/packages/svogg-components/src/lib/styles/index.css
@@ -109,7 +109,7 @@ body {
 
 	position: relative;
 	display: flex;
-	border: var(--border) solid var(--svogg-surface-300);
+	border: var(--border) solid var(--svogg-surface-400);
 	border-radius: 9999px;
 	width: var(--width);
 	aspect-ratio: 2/1;
@@ -131,7 +131,7 @@ body {
 	border-radius: 9999px;
 	height: 100%;
 	aspect-ratio: 1/1;
-	background: var(--svogg-surface-400);
+	background-color: var(--svogg-surface-400);
 	transition: all 0.2s;
 	transform: scale(var(--thumb-scale));
 }

--- a/packages/svogg-components/src/routes/switch/+page.svelte
+++ b/packages/svogg-components/src/routes/switch/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { Switch } from '$lib';
+</script>
+
+<Switch />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,15 @@ importers:
 
   sites/svogg-components.dev:
     devDependencies:
+      '@iconify-json/tabler':
+        specifier: ^1.1.98
+        version: 1.1.98
       '@iconify/svelte':
         specifier: ^3.1.4
         version: 3.1.4(svelte@4.2.3)
+      '@iconify/tailwind':
+        specifier: ^0.1.3
+        version: 0.1.3
       '@sveltejs/adapter-auto':
         specifier: ^2.0.0
         version: 2.1.1(@sveltejs/kit@1.27.5)
@@ -464,6 +470,12 @@ packages:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: true
 
+  /@iconify-json/tabler@1.1.98:
+    resolution: {integrity: sha512-icA0KXNyhaREHZmIDD570lXZnC5TNApiCVwrWOla+Z5KlNNgwfCh1J76MCb3TYQ5gTdB0eC+MGsLqDdBSayR6Q==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: true
+
   /@iconify/svelte@3.1.4(svelte@4.2.3):
     resolution: {integrity: sha512-YDwQlN46ka8KPRayDb7TivmkAPizfTXi6BSRNqa1IV0+byA907n8JcgQafA7FD//pW5XCuuAhVx6uRbKTo+CfA==}
     peerDependencies:
@@ -471,6 +483,12 @@ packages:
     dependencies:
       '@iconify/types': 2.0.0
       svelte: 4.2.3
+    dev: true
+
+  /@iconify/tailwind@0.1.3:
+    resolution: {integrity: sha512-uVV49QtR9cZ9VLxrMSeW1E6iXWeBlpQ0z4aWx7B5WvGEE5OvCjloNYYqwZbZ/W+EsTcApzSm6szqcCVeb9pxDw==}
+    dependencies:
+      '@iconify/types': 2.0.0
     dev: true
 
   /@iconify/types@2.0.0:

--- a/sites/svogg-components.dev/package.json
+++ b/sites/svogg-components.dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svogg-components.dev",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"private": true,
 	"description": "Documentation for svogg-components.",
 	"author": "MikaelJohnAndersson <mikael.andersson@moggstudio.se>",

--- a/sites/svogg-components.dev/package.json
+++ b/sites/svogg-components.dev/package.json
@@ -21,7 +21,9 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
+		"@iconify-json/tabler": "^1.1.98",
 		"@iconify/svelte": "^3.1.4",
+		"@iconify/tailwind": "^0.1.3",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/kit": "^1.20.4",
 		"@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/sites/svogg-components.dev/src/lib/components/LightSwitch.svelte
+++ b/sites/svogg-components.dev/src/lib/components/LightSwitch.svelte
@@ -5,10 +5,11 @@
 
 	let checked = false;
 	$: onChange(checked);
+	$: label = `Change to ${checked ? 'dark' : 'light'} theme`;
 
 	function onChange(_checked: boolean) {
 		if (!browser) return;
-		const theme = checked ? 'light' : 'dark';
+		const theme = _checked ? 'light' : 'dark';
 		const root = document.querySelector('html') as HTMLElement;
 		root.setAttribute('data-theme', theme);
 	}
@@ -20,7 +21,7 @@
 </script>
 
 <div class="contents container">
-	<Switch bind:checked />
+	<Switch bind:checked {label} />
 </div>
 
 <style lang="postcss">

--- a/sites/svogg-components.dev/src/lib/components/LightSwitch.svelte
+++ b/sites/svogg-components.dev/src/lib/components/LightSwitch.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { Switch } from 'svogg-components';
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
+
+	let checked = false;
+	$: onChange(checked);
+
+	function onChange(_checked: boolean) {
+		if (!browser) return;
+		const theme = checked ? 'light' : 'dark';
+		const root = document.querySelector('html') as HTMLElement;
+		root.setAttribute('data-theme', theme);
+	}
+
+	onMount(() => {
+		const systemSettingsLight = window.matchMedia('(prefers-color-scheme: light)');
+		checked = systemSettingsLight.matches;
+	});
+</script>
+
+<div class="contents container">
+	<Switch bind:checked />
+</div>
+
+<style lang="postcss">
+	.container {
+		:global(.svogg-switch::after) {
+			@apply icon-[tabler--moon-filled];
+			position: absolute;
+			content: '';
+			top: 0;
+			left: auto;
+			right: 2px;
+			bottom: 0;
+			margin: auto;
+			transform: scale(0.8);
+		}
+
+		:global(.svogg-switch::before) {
+			@apply icon-[tabler--sun-filled];
+			position: absolute;
+			content: '';
+			top: 0;
+			left: 2px;
+			right: auto;
+			bottom: 0;
+			margin: auto;
+			transform: scale(0.8);
+		}
+
+		:global(.svogg-switch .thumb) {
+			@apply z-10 relative;
+		}
+
+		:global(.svogg-switch.checked) {
+			border-color: var(--svogg-surface-400);
+		}
+
+		:global(.svogg-switch.checked .thumb) {
+			background-color: var(--svogg-surface-400);
+		}
+	}
+</style>

--- a/sites/svogg-components.dev/src/lib/components/Navigation.svelte
+++ b/sites/svogg-components.dev/src/lib/components/Navigation.svelte
@@ -26,6 +26,10 @@
 					href: '/components/drawer'
 				},
 				{
+					title: 'Switch',
+					href: '/components/switch'
+				},
+				{
 					title: 'Tabs',
 					href: '/components/tabs'
 				}

--- a/sites/svogg-components.dev/src/lib/components/index.ts
+++ b/sites/svogg-components.dev/src/lib/components/index.ts
@@ -5,3 +5,4 @@ export { default as Navigation } from './Navigation.svelte';
 export { default as DemoWidget } from './DemoWidget.svelte';
 export { default as Table } from './Table.svelte';
 export { default as IconLinks } from './IconLinks.svelte';
+export { default as LightSwitch } from './LightSwitch.svelte';

--- a/sites/svogg-components.dev/src/routes/+layout.svelte
+++ b/sites/svogg-components.dev/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
 	import '../styles/hljs.css'; // highlight.js styles
 	import { navigating } from '$app/stores';
 	import Icon from '@iconify/svelte';
-	import { Navigation, IconLinks } from '$lib/components';
+	import { Navigation, IconLinks, LightSwitch } from '$lib/components';
 	import { Drawer } from 'svogg-components';
 
 	// @ts-expect-error reading from vite.config.js
@@ -37,7 +37,10 @@
 			<span class="font-mono text-xs">{pkg.version}</span>
 		</div>
 	</div>
-	<div class="hidden sm:contents"><IconLinks /></div>
+	<div class="hidden sm:flex items-center justify-center gap-4">
+		<LightSwitch />
+		<IconLinks />
+	</div>
 </header>
 <Drawer bind:open={drawerOpen} position="left" id="navigation" as="aside">
 	<button
@@ -48,7 +51,10 @@
 	</button>
 	<div class="flex flex-col justify-between h-full">
 		<Navigation />
-		<div class="flex justify-start py-4 mx-4 sm:hidden"><IconLinks /></div>
+		<div class="flex justify-between py-4 mx-4 sm:hidden">
+			<IconLinks />
+			<LightSwitch />
+		</div>
 	</div>
 </Drawer>
 <div class="flex flex-1 overflow-hidden">

--- a/sites/svogg-components.dev/src/routes/components/switch/+page.svelte
+++ b/sites/svogg-components.dev/src/routes/components/switch/+page.svelte
@@ -14,7 +14,7 @@
 			['.thumb', 'Applied to inner element'],
 			['.checked', 'Applied to outer element when checked']
 		],
-		keyboard: [[`<kbd>Enter or Space</kbd>`, ['Toggles checked state']]]
+		keyboard: [[`<kbd>Enter</kbd> or <kbd>Space</kbd>`, ['Toggles checked state']]]
 	};
 
 	let checked = false;
@@ -22,7 +22,27 @@
 
 <DocsShell {settings}>
 	<svelte:fragment slot="description">
-		<p>Toggle switch.</p>
+		<p>
+			Component for toggling a binary state. Uses an internal checkbox element which could be used
+			in conjunction with forms.
+		</p>
+		<br />
+		<p>
+			Not that when overriding styles, CSS variables <code>--width</code> and <code>--border</code> needs
+			to be set with fixed pixel values on the root element in order for the toggle animation to not
+			break. Like so:
+		</p>
+		<br />
+		<CodeBlock
+			code={`
+			.svogg-switch {
+				/* Overrides variables */
+				--width: 48px;
+				--border: 2px;
+			}
+		`}
+			language="css"
+		/>
 	</svelte:fragment>
 	<svelte:fragment slot="demo">
 		<Switch bind:checked />

--- a/sites/svogg-components.dev/src/routes/components/switch/+page.svelte
+++ b/sites/svogg-components.dev/src/routes/components/switch/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { Switch } from 'svogg-components';
+	import sveld from 'svogg-components/components/Switch/Switch.svelte?raw&sveld';
+	import { CodeBlock, DocsShell, DocsType } from '$lib/components';
+	import type { DocsShellSettings } from '$lib/components';
+
+	const settings: DocsShellSettings = {
+		type: DocsType.Component,
+		title: 'Switch',
+		components: [{ name: 'Switch', sveld }],
+		imports: ['Switch'],
+		classes: [
+			['.svogg-switch', 'Applied to outer element'],
+			['.thumb', 'Applied to inner element'],
+			['.checked', 'Applied to outer element when checked']
+		],
+		keyboard: [[`<kbd>Enter or Space</kbd>`, ['Toggles checked state']]]
+	};
+
+	let checked = false;
+</script>
+
+<DocsShell {settings}>
+	<svelte:fragment slot="description">
+		<p>Toggle switch.</p>
+	</svelte:fragment>
+	<svelte:fragment slot="demo">
+		<Switch bind:checked />
+		<span class="py-2">
+			I am {checked ? '' : 'NOT'} checked!
+		</span>
+	</svelte:fragment>
+	<svelte:fragment slot="code">
+		<CodeBlock code={`let checked = false;`} language="typescript" />
+		<CodeBlock
+			code={`
+        <Switch bind:checked />
+        <span class="py-2">
+          I am {checked ? '' : 'NOT'} checked!
+        </span>
+      `}
+		/>
+	</svelte:fragment>
+</DocsShell>

--- a/sites/svogg-components.dev/src/routes/css/+page.svelte
+++ b/sites/svogg-components.dev/src/routes/css/+page.svelte
@@ -208,9 +208,9 @@
 	}
 
 	input[type='range']::-webkit-slider-thumb {
-		@apply shadow rounded-full shadow-black h-full w-6 cursor-pointer;
+		@apply rounded-full h-full w-6 cursor-pointer;
 		-webkit-appearance: none;
-		background: var(--svogg-text);
+		background: white;
 	}
 
 	/***** Chrome, Safari, Opera, and Edge Chromium *****/

--- a/sites/svogg-components.dev/src/styles/app.postcss
+++ b/sites/svogg-components.dev/src/styles/app.postcss
@@ -2,12 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-	--svogg-primary-hue: 200;
-	--svogg-primary-saturation: 100%;
-	--svogg-primary-lightness: 20%;
-}
-
 ::-webkit-scrollbar {
 	width: 0.5rem;
 	height: 0.5rem;

--- a/sites/svogg-components.dev/src/styles/app.postcss
+++ b/sites/svogg-components.dev/src/styles/app.postcss
@@ -22,7 +22,7 @@
 	background-color: var(--svogg-surface-200);
 }
 
-@media (prefers-color-scheme: light) {
+[data-theme='light'] {
 	a[target='_blank'] {
 		@apply text-blue-700;
 
@@ -32,7 +32,7 @@
 	}
 }
 
-@media (prefers-color-scheme: dark) {
+[data-theme='dark'] {
 	a[target='_blank'] {
 		@apply text-blue-400;
 

--- a/sites/svogg-components.dev/src/styles/hljs.css
+++ b/sites/svogg-components.dev/src/styles/hljs.css
@@ -1,4 +1,4 @@
-@media (prefers-color-scheme: light) {
+[data-theme='light'] {
 	pre code.hljs {
 		display: block;
 		overflow-x: auto;
@@ -91,7 +91,7 @@
 	}
 }
 
-@media (prefers-color-scheme: dark) {
+[data-theme='dark'] {
 	pre code.hljs {
 		display: block;
 		overflow-x: auto;

--- a/sites/svogg-components.dev/tailwind.config.js
+++ b/sites/svogg-components.dev/tailwind.config.js
@@ -1,8 +1,13 @@
+import { addDynamicIconSelectors } from '@iconify/tailwind';
+
 /** @type {import('tailwindcss').Config} */
 export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 	theme: {
 		extend: {}
 	},
-	plugins: []
+	plugins: [
+		// Iconify plugin
+		addDynamicIconSelectors()
+	]
 };


### PR DESCRIPTION
**Package**
- Adds `Switch` component 
- Adds CSS support for overriding dark/light system preferences via the `data-theme` property

**Docs**
- Adds page for `Switch`
- Adds lightswitch in header for manually toggling dark/light mode
- Minor style fixes